### PR TITLE
fix(typing): add missing type definitions for useSharedState hook

### DIFF
--- a/packages/core/src/SharedServiceClient.ts
+++ b/packages/core/src/SharedServiceClient.ts
@@ -40,7 +40,7 @@ export class SharedServiceClient extends EventEmitter {
     };
   }
 
-  async setState(key, state) {
+  async setState<T>(key: string, state: T) {
     await this._transport.request({
       payload: {
         action: actionTypes.setState,
@@ -50,14 +50,14 @@ export class SharedServiceClient extends EventEmitter {
     });
   }
 
-  async getState(key) {
+  async getState<T>(key: string): Promise<T> {
     const state = await this._transport.request({
       payload: {
         action: actionTypes.getState,
         key,
       }
     });
-    return state;
+    return state as T;
   }
 
   async execute(funcName: string, args?: any[]) {

--- a/packages/react/src/useSharedState.ts
+++ b/packages/react/src/useSharedState.ts
@@ -36,7 +36,7 @@ export function useSharedState<T>(key: string, initialData: T) {
     return unsubscribe;
   }, []);
 
-  const setData = (newData) => {
+  const setData = (newData: T) => {
     return sharedService.setState(key, newData);
   }
   return [data, setData];


### PR DESCRIPTION
This commit fixes a type inference issue in the useSharedState hook by adding the missing type definitions for the setState and getState methods in the SharedServiceClient and the setData function in the useSharedState hook.

Closes #1